### PR TITLE
feat: Add initial manifest structure with argoCD deployment

### DIFF
--- a/apps/app-of-apps/app-of-apps-production.yaml
+++ b/apps/app-of-apps/app-of-apps-production.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: app-of-apps-production
+spec:
+  destination:
+    namespace: argocd
+    name: production
+  project: default
+  source:
+    path: apps/argocd/overlays/production/apps
+    repoURL: https://github.com/mimotej/jamf-manifests.git
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+    - Validate=false
+    - ApplyOutOfSyncOnly=true

--- a/apps/app-of-apps/kustomization.yaml
+++ b/apps/app-of-apps/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+resources:
+  - app-of-apps-production.yaml

--- a/apps/argocd/base/core/configmaps/argocd-cm/configmap.yaml
+++ b/apps/argocd/base/core/configmaps/argocd-cm/configmap.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+data:
+  kustomize.buildOptions: --enable-helm

--- a/apps/argocd/base/core/configmaps/argocd-cm/kustomization.yaml
+++ b/apps/argocd/base/core/configmaps/argocd-cm/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: argocd
+resources:
+  - configmap.yaml

--- a/apps/argocd/base/core/deployment/argocd-insecure-params.yaml
+++ b/apps/argocd/base/core/deployment/argocd-insecure-params.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+data:
+  server.insecure: "true"

--- a/apps/argocd/base/core/deployment/argocd-service-clusterip.yaml
+++ b/apps/argocd/base/core/deployment/argocd-service-clusterip.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-server
+spec:
+  type: ClusterIP

--- a/apps/argocd/base/core/deployment/kustomization.yaml
+++ b/apps/argocd/base/core/deployment/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: argocd
+resources:
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v2.7.2/manifests/install.yaml
+
+patchesStrategicMerge:
+  - argocd-insecure-params.yaml
+  - argocd-service-clusterip.yaml

--- a/apps/argocd/base/core/ingress/ingress.yaml
+++ b/apps/argocd/base/core/ingress/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-server-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: argocd-jamf.internal
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: argocd-server
+            port:
+              name: http

--- a/apps/argocd/base/core/ingress/kustomization.yaml
+++ b/apps/argocd/base/core/ingress/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+resources:
+  - ingress.yaml

--- a/apps/argocd/base/core/namespaces/argocd/kustomization.yaml
+++ b/apps/argocd/base/core/namespaces/argocd/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/apps/argocd/base/core/namespaces/argocd/namespace.yaml
+++ b/apps/argocd/base/core/namespaces/argocd/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd

--- a/apps/argocd/overlays/production/apps/argocd.yaml
+++ b/apps/argocd/overlays/production/apps/argocd.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd
+spec:
+  destination:
+    namespace: argocd
+    name: argocd
+  project: default
+  source:
+    path: apps/argocd/overlays/production/apps
+    repoURL: https://github.com/mimotej/jamf-manifests.git
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+    - Validate=false
+    - ApplyOutOfSyncOnly=true

--- a/apps/argocd/overlays/production/apps/kustomization.yaml
+++ b/apps/argocd/overlays/production/apps/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+resources:
+  - argocd.yaml

--- a/apps/argocd/overlays/production/kustomization.yaml
+++ b/apps/argocd/overlays/production/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/core/namespaces/argocd
+  - ../../base/core/deployment
+  - ../../base/core/ingress
+  - ../../../app-of-apps

--- a/cluster-scope/base/core/namespaces/go-project/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/go-project/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster-scope/base/core/namespaces/go-project/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/go-project/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: go-project

--- a/cluster-scope/overlays/production/kustomization.yaml
+++ b/cluster-scope/overlays/production/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/core/namespaces/go-project


### PR DESCRIPTION
This PR:

[X] Sets up intial structure of the kustomize manifests
[X] Deploys argocd
[X] Deploys app-of-apps
[X] Deploys argocd project